### PR TITLE
fix: package versions have conflicting dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ executing==1.2.0
 filelock==3.9.0
 fonttools==4.38.0
 frozenlist==1.3.3
-huggingface-hub==0.11.1
+huggingface-hub>=0.0.12
 idna==3.4
 ipykernel==6.20.1
 ipython==8.10.0


### PR DESCRIPTION
Similar issue to: https://github.com/huggingface/transformers/pull/12961

`pip3 install -r requirements.txt` Currently fails with:

```
INFO: pip is looking at multiple versions of transformers to determine which version is compatible with other requirements. This could take a while.
ERROR: Cannot install -r requirements.txt (line 74) and huggingface-hub==0.11.1 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested huggingface-hub==0.11.1
    transformers 4.30.0 depends on huggingface-hub<1.0 and >=0.14.1
```