### PR TITLE
Drop usage of deprecated model text-davinci-003

### DIFF
--- a/web-qa.ipynb
+++ b/web-qa.ipynb
@@ -1083,7 +1083,7 @@
     "\n",
     "def answer_question(\n",
     "    df,\n",
-    "    model=\"text-davinci-003\",\n",
+    "    model=\"gpt-3.5-turbo-instruct\",\n",
     "    question=\"Am I allowed to publish model outputs to Twitter, without a human review?\",\n",
     "    max_len=1800,\n",
     "    size=\"ada\",\n",

--- a/web-qa.py
+++ b/web-qa.py
@@ -351,7 +351,7 @@ def create_context(
 
 def answer_question(
     df,
-    model="text-davinci-003",
+    model="gpt-3.5-turbo-instruct",
     question="Am I allowed to publish model outputs to Twitter, without a human review?",
     max_len=1800,
     size="ada",


### PR DESCRIPTION
This is the minimum required change that I found necessary to get this
example to work. According to the deprecations page [1],
text-davinci-003 was shut down on 2024-01-04. The recommended
replacement is gpt-3.5-turbo-instruct, which is used in this change.

[1]: https://platform.openai.com/docs/deprecations

Signed-off-by: Russell Bryant <russell.bryant@gmail.com>
